### PR TITLE
Add ssh and tls legacy unsafe policies features

### DIFF
--- a/src/ssh-crypto-legacy-unsafe-policies-feature/NOTES.md
+++ b/src/ssh-crypto-legacy-unsafe-policies-feature/NOTES.md
@@ -1,0 +1,16 @@
+## OS Support
+
+This Feature works on recent versions of Redhat UBI distributions. `bash` is required to execute the `install.sh` script. An `ansible-core` bootstrap instance owned by the `ansible` bootstrap user performs the heavy lifting.
+
+## Example Usage
+
+*accept option values*
+
+```json
+// devcontainer.json
+...
+"features": {
+    "./ssh-crypto-legacy-unsafe-policies-feature": {}
+},
+...
+```

--- a/src/ssh-crypto-legacy-unsafe-policies-feature/README.md
+++ b/src/ssh-crypto-legacy-unsafe-policies-feature/README.md
@@ -1,0 +1,35 @@
+# SSH Crypto Unsafe Policies Modification 
+
+## Metadata
+
+| Identifier      | Version |
+| ------- | ------- |
+| ssh-crypto-legacy-unsafe-policies | 1.0.0 |
+
+## Description
+
+A feature to modify SSH crypto policies to allow use of RSA SHA1 keys for authentication on Redhat UBI DevContainers
+
+## Options
+No options available
+
+
+
+---
+
+## OS Support
+
+This Feature works on recent versions of Redhat UBI distributions. `bash` is required to execute the `install.sh` script. An `ansible-core` bootstrap instance owned by the `ansible` bootstrap user performs the heavy lifting.
+
+## Example Usage
+
+*accept option values*
+
+```json
+// devcontainer.json
+...
+"features": {
+    "./ssh-crypto-legacy-unsafe-policies-feature": {}
+},
+...
+```

--- a/src/ssh-crypto-legacy-unsafe-policies-feature/activate-feature.yml
+++ b/src/ssh-crypto-legacy-unsafe-policies-feature/activate-feature.yml
@@ -1,0 +1,40 @@
+# feature-playbook.yml
+# CAUTION: Only run this playbook if you suffer from SSH authentication issues caused by a platform only supporting SHA1 keys; 
+# Azure DevOps/TFS is just such a platform. Ultimately, this change reduces the security profile of your container; Just be aware.
+---
+- name: Configure crypto policies for RHEL
+  hosts: ubi
+  become: yes
+  tasks:
+    - name: Ensure /etc/crypto-policies/back-ends/opensshserver.config exists
+      ansible.builtin.copy:
+        dest: /etc/crypto-policies/back-ends/opensshserver.config
+        content: ""
+        force: no
+        mode: 0644
+
+    - name: Append ssh-rsa to PubkeyAcceptedAlgorithms in opensshserver.config
+      ansible.builtin.lineinfile:
+        path: /etc/crypto-policies/back-ends/opensshserver.config
+        regexp: '^(PubkeyAcceptedAlgorithms.*)'
+        line: '\1,ssh-rsa'
+        backrefs: yes
+
+    - name: Update crypto policies
+      ansible.builtin.command:
+        cmd: update-crypto-policies --set DEFAULT:SHA1
+      register: update_result
+      changed_when: "'Setting system policy to' in update_result.stdout"
+
+# Normally we want to restart sshd but not in containers
+  # handlers:
+  #   - name: Restart sshd
+  #     ansible.builtin.systemd:
+  #       name: sshd
+  #       state: restarted
+  #     listen: restart_sshd
+
+  # post_tasks:
+  #   - name: Notify sshd restart
+  #     ansible.builtin.meta:
+  #       flush_handlers

--- a/src/ssh-crypto-legacy-unsafe-policies-feature/devcontainer-feature.json
+++ b/src/ssh-crypto-legacy-unsafe-policies-feature/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+    "name": "SSH Crypto Unsafe Policies Modification",
+    "id": "ssh-crypto-legacy-unsafe-policies",
+    "version": "1.0.0",
+    "description": "A feature to modify SSH crypto policies to allow use of RSA SHA1 keys for authentication on Redhat UBI DevContainers",
+    "options": {},
+    "installsAfter": []
+}

--- a/src/ssh-crypto-legacy-unsafe-policies-feature/install.sh
+++ b/src/ssh-crypto-legacy-unsafe-policies-feature/install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# ssh-crypto-legacy-unsafe-policies-feature/install.sh
+# Licensed under the MIT License.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: 
+# Maintainer: infrashift.sh
+#
+# Notes: This is the feature activation entrypoint script; It is ALWAYS executed as the 'root' user.
+set -e
+
+echo "                                                                                "
+echo "********************************************************************************"
+echo "BEGIN FEATURE ACTIVATION                                                        "
+echo "Activating feature 'ssh-crypto-legacy-unsafe-policies'...                       "
+echo "********************************************************************************"
+echo "                                                                                "
+
+# The 'install.sh' entrypoint script is always executed as the root user.
+#
+# These following environment variables are passed in by the dev container CLI.
+# These may be useful in instances where the context of the final 
+# remoteUser or containerUser is useful.
+# For more details, see https://containers.dev/implementors/features#user-env-var
+echo "The effective DevContainer remoteUser is '${_REMOTE_USER}'"
+echo "The effective DevContainer remoteUser's home directory is '${_REMOTE_USER_HOME}'"
+
+echo "The effective DevContainer containerUser is '${_CONTAINER_USER}'"
+echo "The effective DevContainer containerUser's home directory is '${_CONTAINER_USER_HOME}'"
+
+echo "The effective DevContainer Feature user is '${SECUREDEVCONTAINER_FEATURE_USERNAME}'"
+echo "The effective DevContainer Feature user UID is '${SECUREDEVCONTAINER_FEATURE_USER_UID}'"
+echo "The effective DevContainer Feature user GID is '${SECUREDEVCONTAINER_FEATURE_USER_GID}'"
+echo "The effective DevContainer Feature user home is '${SECUREDEVCONTAINER_FEATURE_USER_HOME}'"
+
+# List feature installation assets
+ls -al .
+
+# Change ownership of feature installation assets
+chown -R ${SECUREDEVCONTAINER_FEATURE_USERNAME}:${SECUREDEVCONTAINER_FEATURE_USERNAME} .
+echo ""
+
+# Execute ansible-inventory as the Secure DevContainer Feature user
+# This will showcase issues with the inventory before making use of the inventory to run the activate-feature playbook
+echo "Parsing Ansible Inventory for host 'localhost'..."
+su -s /bin/bash ${SECUREDEVCONTAINER_FEATURE_USERNAME} <<EOF
+    ${SECUREDEVCONTAINER_FEATURE_USER_LOCAL_BIN_PATH}/ansible-inventory --inventory ${SECUREDEVCONTAINER_FEATURE_USER_HOME}/hosts.yml --host localhost --yaml
+EOF
+echo ""
+
+# Execute ansible-playbook as 'ansible' user
+su -s /bin/bash ${SECUREDEVCONTAINER_FEATURE_USERNAME} <<EOF
+    ${SECUREDEVCONTAINER_FEATURE_USER_LOCAL_BIN_PATH}/ansible-playbook --inventory ${SECUREDEVCONTAINER_FEATURE_USER_HOME}/hosts.yml activate-feature.yml
+EOF
+
+echo "                                                                                "
+echo "********************************************************************************"
+echo "END FEATURE ACTIVATION                                                          "
+echo "********************************************************************************"
+echo "                                                                                "
+

--- a/src/tls-crypto-legacy-unsafe-policies-feature/NOTES.md
+++ b/src/tls-crypto-legacy-unsafe-policies-feature/NOTES.md
@@ -1,0 +1,16 @@
+## OS Support
+
+This Feature works on recent versions of Redhat UBI distributions. `bash` is required to execute the `install.sh` script. An `ansible-core` bootstrap instance owned by the `ansible` bootstrap user performs the heavy lifting.
+
+## Example Usage
+
+*accept option values*
+
+```json
+// devcontainer.json
+...
+"features": {
+    "./tls-crypto-legacy-unsafe-policies-feature": {}
+},
+...
+```

--- a/src/tls-crypto-legacy-unsafe-policies-feature/README.md
+++ b/src/tls-crypto-legacy-unsafe-policies-feature/README.md
@@ -1,0 +1,35 @@
+# TLS Crypto Policies Unsafe Modification 
+
+## Metadata
+
+| Identifier      | Version |
+| ------- | ------- |
+| tls-crypto-policies-unsafe-mod | 1.0.0 |
+
+## Description
+
+A feature to modify TLS crypto policies to allow UnsafeLegacyRenegotiation on Redhat UBI DevContainers
+
+## Options
+No options available
+
+
+
+---
+
+## OS Support
+
+This Feature works on recent versions of Redhat UBI distributions. `bash` is required to execute the `install.sh` script. An `ansible-core` bootstrap instance owned by the `ansible` bootstrap user performs the heavy lifting.
+
+## Example Usage
+
+*accept option values*
+
+```json
+// devcontainer.json
+...
+"features": {
+    "./tls-crypto-legacy-unsafe-policies-feature": {}
+},
+...
+```

--- a/src/tls-crypto-legacy-unsafe-policies-feature/activate-feature.yml
+++ b/src/tls-crypto-legacy-unsafe-policies-feature/activate-feature.yml
@@ -1,0 +1,28 @@
+# ssh-crypto-policies-mod.yml
+# CAUTION: Only run this playbook if you suffer from TLS 1.3 to TLS < 1.3 negotiation errors that cannot be immediately and securely resolved.
+#          This is a common issue on RHEL8/9 and CentOS Stream 8/9. This change allows unsafe legacy renegotiation during TLS handshake by 
+#          setting UnsafeLegacyRenegotiation. Ultimately, this change reduces the security profile of your container; Just be aware.
+# feature-playbook.yml
+---
+- name: Configure UnsafeLegacyRenegotiation in OpenSSL
+  hosts: ubi
+  become: yes
+  tasks:
+    - name: Ensure /etc/pki/tls/openssl.cnf exists
+      ansible.builtin.stat:
+        path: /etc/pki/tls/openssl.cnf
+      register: openssl_config_stat
+
+    - name: Fail if /etc/pki/tls/openssl.cnf does not exist
+      ansible.builtin.fail:
+        msg: "/etc/pki/tls/openssl.cnf does not exist"
+      when: not openssl_config_stat.stat.exists
+
+    - name: Insert UnsafeLegacyRenegotiation under [crypto_policy] in openssl.cnf
+      ansible.builtin.blockinfile:
+        path: /etc/pki/tls/openssl.cnf
+        marker: "# {mark} ANSIBLE MANAGED BLOCK"
+        insertafter: '^\[ crypto_policy \]'
+        block: |
+          Options = UnsafeLegacyRenegotiation
+...

--- a/src/tls-crypto-legacy-unsafe-policies-feature/devcontainer-feature.json
+++ b/src/tls-crypto-legacy-unsafe-policies-feature/devcontainer-feature.json
@@ -1,0 +1,21 @@
+{
+    "name": "TLS Crypto Policies Unsafe Modification",
+    "id": "tls-crypto-policies-unsafe-mod",
+    "version": "1.0.0",
+    "description": "A feature to modify TLS crypto policies to allow UnsafeLegacyRenegotiation on Redhat UBI DevContainers",
+    // "options": {
+    //     "favorite": {
+    //         "type": "string",
+    //         "enum": [
+    //             "red",
+    //             "gold",
+    //             "green"
+    //         ],
+            // "default": "red",
+        //     "description": "Choose your favorite color."
+        // }
+    // },
+    "installsAfter": [
+        // "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/src/tls-crypto-legacy-unsafe-policies-feature/install.sh
+++ b/src/tls-crypto-legacy-unsafe-policies-feature/install.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# tls-crypto-legacy-unsafe-policies-feature/install.sh
+# Licensed under the MIT License.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: 
+# Maintainer: infrashift.sh
+#
+# Notes: This is the feature activation entrypoint script; It is ALWAYS executed as the 'root' user.
+set -e
+
+echo "                                                                                "
+echo "********************************************************************************"
+echo "BEGIN FEATURE ACTIVATION                                                        "
+echo "Activating feature 'tls-crypto-policies-unsafe'...                              "
+echo "********************************************************************************"
+echo "                                                                                "
+
+# The 'install.sh' entrypoint script is always executed as the root user.
+#
+# These following environment variables are passed in by the dev container CLI.
+# These may be useful in instances where the context of the final 
+# remoteUser or containerUser is useful.
+# For more details, see https://containers.dev/implementors/features#user-env-var
+echo "The effective DevContainer remoteUser is '${_REMOTE_USER}'"
+echo "The effective DevContainer remoteUser's home directory is '${_REMOTE_USER_HOME}'"
+
+echo "The effective DevContainer containerUser is '${_CONTAINER_USER}'"
+echo "The effective DevContainer containerUser's home directory is '${_CONTAINER_USER_HOME}'"
+
+echo "The effective DevContainer Feature user is '${SECUREDEVCONTAINER_FEATURE_USERNAME}'"
+echo "The effective DevContainer Feature user UID is '${SECUREDEVCONTAINER_FEATURE_USER_UID}'"
+echo "The effective DevContainer Feature user GID is '${SECUREDEVCONTAINER_FEATURE_USER_GID}'"
+echo "The effective DevContainer Feature user home is '${SECUREDEVCONTAINER_FEATURE_USER_HOME}'"
+
+# List feature installation assets
+ls -al .
+
+# Change ownership of feature installation assets
+chown -R ${SECUREDEVCONTAINER_FEATURE_USERNAME}:${SECUREDEVCONTAINER_FEATURE_USERNAME} .
+echo ""
+
+# Execute ansible-inventory as the Secure DevContainer Feature user
+# This will showcase issues with the inventory before making use of the inventory to run the activate-feature playbook
+echo "Parsing Ansible Inventory for host 'localhost'..."
+su -s /bin/bash ${SECUREDEVCONTAINER_FEATURE_USERNAME} <<EOF
+    ${SECUREDEVCONTAINER_FEATURE_USER_LOCAL_BIN_PATH}/ansible-inventory --inventory ${SECUREDEVCONTAINER_FEATURE_USER_HOME}/hosts.yml --host localhost --yaml
+EOF
+echo ""
+
+# Execute ansible-playbook as 'ansible' user
+su -s /bin/bash ${SECUREDEVCONTAINER_FEATURE_USERNAME} <<EOF
+    ${SECUREDEVCONTAINER_FEATURE_USER_LOCAL_BIN_PATH}/ansible-playbook --inventory ${SECUREDEVCONTAINER_FEATURE_USER_HOME}/hosts.yml activate-feature.yml
+EOF
+
+echo "                                                                                "
+echo "********************************************************************************"
+echo "END FEATURE ACTIVATION                                                          "
+echo "********************************************************************************"
+echo "                                                                                "
+


### PR DESCRIPTION
#11 SSH legacy unsafe policies
#12 TLS legacy unsafe policies

These exist to workaround issues with M$ Azure DevOps/TFS on-premises server.